### PR TITLE
fix naming of the "getSensorAvaliable" function

### DIFF
--- a/lib/environment_sensors.dart
+++ b/lib/environment_sensors.dart
@@ -35,8 +35,8 @@ class EnvironmentSensors {
   ///Stream of pressure readings
   Stream<double>? _pressureEvents;
 
-  ///Check for the availabilitity of device sensor by sensor type.
-  Future<bool> getSensorAvailable(SensorType sensorType) async {
+  ///Check for the availability of device sensor by sensor type.
+  Future<bool> isSensorAvaliable(SensorType sensorType) async {
     if (sensorType == SensorType.AmbientTemperature)
       return await _methodChannel.invokeMethod('isSensorAvailable', 13);
     if (sensorType == SensorType.Humidity)


### PR DESCRIPTION
"get" is for retrieving value, while "is" is a redefinition of a "get" that returns a bool -> extra readability