### PR TITLE
Update Kotlin Version in build.gradle and gradle.properties to latest Version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: '*/1440 * * * *' 
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: tgymnich/fork-sync@v1.8
+        with:
+          owner: llvm
+          base: master
+          head: master
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,2 @@
-name: Sync Fork
 
-on:
-  schedule:
-    - cron: '*/1440 * * * *' 
-  workflow_dispatch: # on button click
-
-jobs:
-  sync:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: tgymnich/fork-sync@v1.8
-        with:
-          owner: llvm
-          base: master
-          head: master
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,5 +36,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    //implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.julow.environment_sensors'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         jcenter()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+kotlinVersion=1.9.0


### PR DESCRIPTION
Update Kotlin version to latest to prevent the following Errors:
```
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.
The following dependencies do not satisfy the required version:
project ':environment_sensors' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50
```